### PR TITLE
'Converting circular structure to JSON' on invoke local

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,4 @@
 
 const { createServer, proxy } = require('aws-serverless-express');
 
-module.exports = app => (event, ctx) => proxy(createServer(app.callback()), event, ctx);
+module.exports = app => (event, ctx) => { proxy(createServer(app.callback()), event, ctx); }


### PR DESCRIPTION
Proxy must execute the request received by the handler, not return the proxy object itself.

Else you will get errors when executing: `serverless invoke local --function [function_name]`

Fixes https://github.com/compwright/aws-serverless-koa/issues/2