### PR TITLE
Storing server as a variable as to not recreate one every event

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,7 @@
 
 const { createServer, proxy } = require('aws-serverless-express');
 
-module.exports = app => (event, ctx) => { proxy(createServer(app.callback()), event, ctx); }
+module.exports = app => {
+  const server = createServer(app.callback());
+  return (event, ctx) => { proxy(server, event, ctx); };
+};


### PR DESCRIPTION
Currently the server is recreated on every request and this leads to an EMFILE error as the number of open sockets reaches a maximum.  The server does not need to be recreated on every event, and should be cached between events.